### PR TITLE
fixed deallocation of nil projections bug

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,4 +14,5 @@
 # Dependency directories (remove the comment below to include it)
 # vendor/
 .idea/workspace.xml
+.idea/encodings.xml
 output/

--- a/converters/converters.go
+++ b/converters/converters.go
@@ -129,7 +129,7 @@ func initProjection(code int) (*proj.Proj, error) {
 // Releases a projection object from memory
 func DeallocateProjection(code int) {
 	val, ok := EpsgDatabase[code]
-	if ok {
+	if ok && val.Projection != nil {
 		val.Projection.Close()
 		EpsgDatabase[code].Projection = nil;
 	}


### PR DESCRIPTION
When no coordinate conversion is performed not Projection object is allocated, thus no deallocation should be performed. This PR is to fix a bug where a deallocation of a nil Projection object was attempted resulting in a fatal error.