### PR TITLE
Bugfix/issue 12 fix executable path

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,9 @@ propeties named `INTENSITY` and `CLASSIFICATION`.
 
 
 ## Changelog
+##### Version 1.1.1 
+* Fixed a bug that prevented the executable to be used on computers other than the one where the code was built.
+
 ##### Version 1.1.0 
 * Added a new tiling algorithm that greatly improves the output quality.
 
@@ -66,6 +69,9 @@ To launch the tests use the command `go test ./test/... -v`.
 ## Usage
 
 <b>The code expects to find a copy of the [static](assets) folder in the same path where the compiled executable runs.</b>
+
+> Alternatively, from version 1.1.1 you can also specify the assets folder location (i.e. the folder that contains the `assets` folder) 
+by setting the `GOCESIUMTILER_WORKDIR` environment variable in your system.
 
 To run just execute the binary tool with the appropriate flags.
 
@@ -111,7 +117,6 @@ gocesiumtiler -help
   -x float              Max cell size in meters for the grid algorithm. It roughly represents the max spacing between any two samples.  (shorthand for grid-max-size) (default 5)
   -z float              Vertical offset to apply to points, in meters. (shorthand for zoffset)
   -zoffset float        Vertical offset to apply to points, in meters.
-
 ```
 
 Note: the "hq" flag present in versions <= 1.0.3 has been removed and replaced by the "randombox" setting for the `-algorithm` flag.

--- a/internal/converters/coordinate/proj4_coordinate_converter/proj4_coordinate_converter.go
+++ b/internal/converters/coordinate/proj4_coordinate_converter/proj4_coordinate_converter.go
@@ -22,7 +22,7 @@ type proj4CoordinateConverter struct {
 }
 
 func NewProj4CoordinateConverter() converters.CoordinateConverter {
-	exPath := tools.GetExecutablePath()
+	exPath := tools.GetRootFolder()
 
 	// Set path for retrieving projection assets data
 	proj.SetFinder([]string{path.Join(exPath, "assets", "share")})

--- a/internal/converters/geoid_offset/gh_offset_calculator/earth_gravitational_model.go
+++ b/internal/converters/geoid_offset/gh_offset_calculator/earth_gravitational_model.go
@@ -64,7 +64,7 @@ func newEarthGraviationalModel(nmax int, wgs84 bool) *egm {
 	model.snmGeopCoef = make([]float64, geopCoefLength)
 	model.as = make([]float64, nmax+1)
 
-	exPath := tools.GetExecutablePath()
+	exPath := tools.GetRootFolder()
 
 	// Loading Earth Gravitational Model data
 	err := model.load(path.Join(exPath, "assets", "egm180.nor"))

--- a/main.go
+++ b/main.go
@@ -36,7 +36,7 @@ import (
 	// "github.com/pkg/profile" // enable for profiling
 )
 
-const VERSION = "1.1.0"
+const VERSION = "1.1.1"
 
 const logo = `
                            _                 _   _ _

--- a/test/unit/std_consumer_test.go
+++ b/test/unit/std_consumer_test.go
@@ -35,7 +35,7 @@ func TestConsumerSinglePointNoChildrenEPSG4326(t *testing.T) {
 	}
 
 	// generate a temp dir and defer its deletion
-	tempdir, _ := ioutil.TempDir(tools.GetExecutablePath(), "temp*")
+	tempdir, _ := ioutil.TempDir(tools.GetRootFolder(), "temp*")
 	defer func() { _ = os.RemoveAll(tempdir) }()
 
 	// generate a mock workunit
@@ -271,7 +271,7 @@ func TestConsumerSinglePointNoChildrenEPSG32633(t *testing.T) {
 	}
 
 	// generate a temp dir and defer its deletion
-	tempdir, _ := ioutil.TempDir(tools.GetExecutablePath(), "temp*")
+	tempdir, _ := ioutil.TempDir(tools.GetRootFolder(), "temp*")
 	defer func() { _ = os.RemoveAll(tempdir) }()
 
 	// generate a mock workunit
@@ -522,7 +522,7 @@ func TestConsumerOneChild(t *testing.T) {
 	}
 
 	// generate a temp dir and defer its deletion
-	tempdir, _ := ioutil.TempDir(tools.GetExecutablePath(), "temp*")
+	tempdir, _ := ioutil.TempDir(tools.GetRootFolder(), "temp*")
 	defer func() { _ = os.RemoveAll(tempdir) }()
 
 	// generate a mock workunit

--- a/tools/io.go
+++ b/tools/io.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"path/filepath"
 	"runtime"
+	"strings"
 )
 
 func OpenFileOrFail(filePath string) *os.File {
@@ -16,9 +17,20 @@ func OpenFileOrFail(filePath string) *os.File {
 	return file
 }
 
-func GetExecutablePath() string {
-	_, b, _, _ := runtime.Caller(0)
-	return filepath.Dir(filepath.Dir(b))
+func GetRootFolder() string {
+	assetsFromEnv := os.Getenv("GOCESIUMTILER_WORKDIR")
+	if assetsFromEnv != "" {
+		return assetsFromEnv
+	} else if strings.HasSuffix(os.Args[0], ".test") || strings.HasSuffix(os.Args[0], ".test.exe") {
+		_, b, _, _ := runtime.Caller(0)
+		return filepath.Dir(filepath.Dir(b))
+	} else {
+		ex, err := os.Executable()
+		if err != nil {
+			log.Fatal("cannot retrieve executable directory", err)
+		}
+		return filepath.Dir(ex)
+	}
 }
 
 func CreateDirectoryIfDoesNotExist(directory string) error {


### PR DESCRIPTION
Fixes a bug that resulted in the absolute path of the repository being hardcoded in the compiled output. Also adds support for the `GOCESIUMTILER_WORKDIR` environment variable to specify a custom location for the assets directory.