### PR TITLE
Add option to support LAS files with 8bit color depth. Bugfixes.

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,11 @@ propeties named `INTENSITY` and `CLASSIFICATION`.
 
 
 ## Changelog
+##### Version 1.2.1
+* Added option to support LAS files with 8bit color depth.
+* Fixed a bug when processing multiple files.
+* Fixed a bug in computing the geometric error of the lowest level of detail tile.
+
 ##### Version 1.2.0 
 * Added support for `REPLACE` refine mode. Default refine mode is still `ADD`.
 
@@ -90,8 +95,10 @@ gocesiumtiler -help
 ### Flags
 
 ```
+  -8bit                 Assumes the input LAS has colors encoded in eight bit format. Default is false (LAS has 16 bit color depth)
   -a string             Sets the algorithm to use. Must be one of Grid,Random,RandomBox. Grid algorithm is highly suggested, others are deprecated and will be removed in future versions. (shorthand for algorithm) (default "grid")
   -algorithm string     Sets the algorithm to use. Must be one of Grid,Random,RandomBox. Grid algorithm is highly suggested, others are deprecated and will be removed in future versions. (default "grid")
+  -b                    Assumes the input LAS has colors encoded in eight bit format. Default is false (LAS has 16 bit color depth). (shorthand for -8bit)
   -e int                EPSG srid code of input points. (shorthand for srid) (default 4326)
   -f                    Enables processing of all las files from input folder. Input must be a folder if specified (shorthand for folder)
   -folder               Enables processing of all las files from input folder. Input must be a folder if specified

--- a/internal/octree/grid_tree/grid_node.go
+++ b/internal/octree/grid_tree/grid_node.go
@@ -121,6 +121,12 @@ func (n *GridNode) IsRoot() bool {
 
 // Computes the geometric error for the given GridNode
 func (n *GridNode) ComputeGeometricError() float64 {
+	if n.IsRoot() {
+		var w = math.Abs(n.boundingBox.Xmax - n.boundingBox.Xmin)
+		var l = math.Abs(n.boundingBox.Ymax - n.boundingBox.Ymin)
+		var h = math.Abs(n.boundingBox.Zmax - n.boundingBox.Zmin)
+		return math.Sqrt(w * w + l * l + h * h)
+	}
 	// geometric error is estimated as the maximum possible distance between two points lying in the cell
 	return n.cellSize * math.Sqrt(3) * 2
 }

--- a/internal/tiler/options.go
+++ b/internal/tiler/options.go
@@ -46,6 +46,7 @@ type TilerOptions struct {
 	Input                  string     // Input LAS file/folder
 	Output                 string     // Output Cesium Tileset folder
 	Srid                   int        // EPSG code for SRID of input LAS points
+	EightBitColors         bool       // if true assume that LAS uses 8bit color depth
 	ZOffset                float64    // Z Offset in meters to apply to points during conversion
 	MaxNumPointsPerNode    int32      // Maximum allowed number of points per node for Random and RandomBox Algorithms
 	EnableGeoidZCorrection bool       // Enables the conversion from geoid to ellipsoid height

--- a/main.go
+++ b/main.go
@@ -81,6 +81,7 @@ func main() {
 		Input:                  *flags.Input,
 		Output:                 *flags.Output,
 		Srid:                   *flags.Srid,
+		EightBitColors:         *flags.EightBitColors,
 		ZOffset:                *flags.ZOffset,
 		MaxNumPointsPerNode:    int32(*flags.MaxNumPts),
 		EnableGeoidZCorrection: *flags.ZGeoidCorrection,

--- a/pkg/tiler.go
+++ b/pkg/tiler.go
@@ -39,11 +39,10 @@ func (tiler *Tiler) RunTiler(opts *tiler.TilerOptions) error {
 	// Prepare list of files to process
 	lasFiles := tiler.fileFinder.GetLasFilesToProcess(opts)
 
-	// Define point_loader strategy
-	var tree = tiler.algorithmManager.GetTreeAlgorithm()
-
 	// load las points in octree buffer
 	for i, filePath := range lasFiles {
+		// Define point_loader strategy
+		var tree = tiler.algorithmManager.GetTreeAlgorithm()
 		tools.LogOutput("Processing file " + strconv.Itoa(i+1) + "/" + strconv.Itoa(len(lasFiles)))
 		tiler.processLasFile(filePath, opts, tree)
 	}
@@ -100,7 +99,7 @@ func readLas(file string, opts *tiler.TilerOptions, tree octree.ITree) error {
 	var lf *lidario.LasFile
 	var err error
 	var lasFileLoader = lidario.NewLasFileLoader(tree)
-	lf, err = lasFileLoader.LoadLasFile(file, opts.Srid)
+	lf, err = lasFileLoader.LoadLasFile(file, opts.Srid, opts.EightBitColors)
 	if err != nil {
 		return err
 	}

--- a/test/unit/grid_node_test.go
+++ b/test/unit/grid_node_test.go
@@ -319,10 +319,25 @@ func TestGridNodeComputeGeometricError(t *testing.T) {
 		geometry.NewBoundingBox(14, 15, 41, 42, 1, 2),
 		1.0,
 		0.5,
-		true,
+		false,
 	)
 
 	expectedError := 1.0 * math.Sqrt(3) * 2
+	if node.ComputeGeometricError() != expectedError {
+		t.Errorf("Expected ComputeGeometricError %f, got %f", expectedError, node.ComputeGeometricError())
+	}
+}
+
+func TestRootGridNodeComputeGeometricError(t *testing.T) {
+	node := grid_tree.NewGridNode(
+		nil,
+		geometry.NewBoundingBox(14, 16, 41, 42, 1, 2),
+		1.0,
+		0.5,
+		true,
+	)
+
+	expectedError := 1.0 * math.Sqrt(4 + 1 + 1)
 	if node.ComputeGeometricError() != expectedError {
 		t.Errorf("Expected ComputeGeometricError %f, got %f", expectedError, node.ComputeGeometricError())
 	}

--- a/tools/flags.go
+++ b/tools/flags.go
@@ -8,6 +8,7 @@ type Flags struct {
 	Input                     *string
 	Output                    *string
 	Srid                      *int
+	EightBitColors  		   *bool
 	ZOffset                   *float64
 	MaxNumPts                 *int
 	ZGeoidCorrection          *bool
@@ -27,6 +28,7 @@ func ParseFlags() Flags {
 	input := defineStringFlag("input", "i", "", "Specifies the input las file/folder.")
 	output := defineStringFlag("output", "o", "", "Specifies the output folder where to write the tileset data.")
 	srid := defineIntFlag("srid", "e", 4326, "EPSG srid code of input points.")
+	eightBit := defineBoolFlag("8bit", "b", false, "Assumes the input LAS has colors encoded in eight bit format. Default is false (LAS has 16 bit color depth)")
 	zOffset := defineFloat64Flag("zoffset", "z", 0, "Vertical offset to apply to points, in meters.")
 	maxNumPts := defineIntFlag("maxpts", "m", 50000, "Max number of points per tile for the Random and RandomBox algorithms.")
 	zGeoidCorrection := defineBoolFlag("geoid", "g", false, "Enables Geoid to Ellipsoid elevation correction. Use this flag if your input LAS files have Z coordinates specified relative to the Earth geoid rather than to the standard ellipsoid.")
@@ -47,6 +49,7 @@ func ParseFlags() Flags {
 		Input:                     input,
 		Output:                    output,
 		Srid:                      srid,
+		EightBitColors:            eightBit,
 		ZOffset:                   zOffset,
 		MaxNumPts:                 maxNumPts,
 		ZGeoidCorrection:          zGeoidCorrection,


### PR DESCRIPTION
This CR addresses most of the open issues:
- A new flag has been added to support LAS files with colors encoded using 8bit color space.
- The way the geometric error is computed for the first tile in the tree has been changed to provide a more correct estimation of the error. This should prevent issues with the tileset disappearing when zooming out.
- A bug that was preventing the system from processing multiple LAS files in a folder should have been fixed.