### PR TITLE
Fix multiple files processing bug and LAS RGB color parsing logic.

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,10 @@ propeties named `INTENSITY` and `CLASSIFICATION`.
 
 
 ## Changelog
+##### Version 1.2.2
+* Fixed a bug in parsing RGB colors for LAS files having point records of non standard length.
+* Fixed a bug when processing multiple files (this was not really fixed in the previous version).
+
 ##### Version 1.2.1
 * Added option to support LAS files with 8bit color depth.
 * Fixed a bug when processing multiple files.

--- a/main.go
+++ b/main.go
@@ -36,7 +36,7 @@ import (
 	// "github.com/pkg/profile" // enable for profiling
 )
 
-const VERSION = "1.2.1"
+const VERSION = "1.2.2"
 
 const logo = `
                            _                 _   _ _

--- a/pkg/algorithm_manager/std_algorithm_manager/std_algorithm_manager.go
+++ b/pkg/algorithm_manager/std_algorithm_manager/std_algorithm_manager.go
@@ -19,7 +19,6 @@ type StandardAlgorithmManager struct {
 	options             *tiler.TilerOptions
 	coordinateConverter converters.CoordinateConverter
 	elevationCorrector  converters.ElevationCorrector
-	treeStructure       octree.ITree
 }
 
 func NewAlgorithmManager(opts *tiler.TilerOptions) algorithm_manager.AlgorithmManager {
@@ -31,7 +30,6 @@ func NewAlgorithmManager(opts *tiler.TilerOptions) algorithm_manager.AlgorithmMa
 		options:             opts,
 		coordinateConverter: coordinateConverter,
 		elevationCorrector:  elevationCorrectionAlgorithm,
-		treeStructure:       evaluateTreeAlgorithm(opts, coordinateConverter, elevationCorrectionAlgorithm),
 	}
 
 	return algorithmManager
@@ -42,7 +40,7 @@ func (am *StandardAlgorithmManager) GetElevationCorrectionAlgorithm() converters
 }
 
 func (am *StandardAlgorithmManager) GetTreeAlgorithm() octree.ITree {
-	return am.treeStructure
+	return evaluateTreeAlgorithm(am.options, am.coordinateConverter, am.elevationCorrector)
 }
 
 func (am *StandardAlgorithmManager) GetCoordinateConverterAlgorithm() converters.CoordinateConverter {


### PR DESCRIPTION
Fixes a bug preventing the processing of multiple files when using the -f flag due to a resue of a non empty octree structure.
The issue here is that previously a tree data structure was initialized at the moment of the instantiation of the algorithm manager, rather than on request. The fix is thus to instantiate and return the data structure when GetTreeAlgorithm is invoked.

Fixes a bug in the logic to parse RGB point colors occurring in case of LAS point records containing custom metadata and non standard length. The las library that is used apparently was not following correctly the LAS 1.4 specifications which require optional fields to be specified with default values. Previously the logic was simply assuming the bytes were omitted, but this is not correct. The fix is thus to simply assume that all fields, including the optional ones, are present.