### PR TITLE
Fix race condition in combined LAS reader

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,9 @@ You can preview a couple of tilesets generated from this tool at this [website](
 
 
 ## Changelog
+##### Version 2.0.1
+* Resolved a bug that prevented the correct functioning of the join flag when processing multiple LAS files from a folder.
+
 ##### Version 2.0.0
 * Most of the code has been rewritten from the ground up, achieving much faster tiling with lower memory usage
 * Uses Proj v9.5.0: all projections supported by the Proj library are automatically supported by gocesiumtiler.

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -23,7 +23,7 @@ var tilerProvider func() (tiler.Tiler, error) = func() (tiler.Tiler, error) {
 	return tiler.NewGoCesiumTiler()
 }
 
-var cmdVersion = "2.0.0"
+var cmdVersion = "2.0.1"
 
 // GitCommit is injected dynamically at build time via `go build -ldflags "-X main.GitCommit=XYZ"`
 var GitCommit string = "(na)"

--- a/internal/las/golas/reader.go
+++ b/internal/las/golas/reader.go
@@ -219,6 +219,7 @@ func (g *Las) Next() (Point, error) {
 	// a Seek operation right before returning the struct
 	g.Lock()
 	if g.current >= g.NumberOfPoints() {
+		g.Unlock()
 		return p, io.EOF
 	}
 	data := make([]byte, g.Header.PointDataRecordLength)

--- a/internal/las/reader_test.go
+++ b/internal/las/reader_test.go
@@ -3,6 +3,7 @@ package las
 import (
 	"fmt"
 	"os"
+	"sync"
 	"testing"
 )
 
@@ -40,5 +41,56 @@ func TestCombinedReader(t *testing.T) {
 	_, err = r.GetNext()
 	if err == nil {
 		t.Errorf("expected error, got none")
+	}
+}
+
+func TestCombinedReaderConcurrency(t *testing.T) {
+	entries, err := os.ReadDir("./testdata")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	files := []string{}
+	for _, e := range entries {
+		filename := e.Name()
+		files = append(files, fmt.Sprintf("./testdata/%s", filename))
+	}
+
+	r, err := NewCombinedFileLasReader(files, "EPSG:32633", false)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if actual := r.NumberOfPoints(); actual != 10*len(files) {
+		t.Errorf("expected %d points got %d", 10*len(files), actual)
+	}
+
+	if actual := r.GetCRS(); actual != "EPSG:32633" {
+		t.Errorf("expected epsg %d got epsg %s", 32633, actual)
+	}
+
+	e := make(chan error, 10)
+	readFun := func(wg *sync.WaitGroup) {
+		defer wg.Done()
+		read := 0
+		for i := 0; i < r.NumberOfPoints()/5; i++ {
+			_, err := r.GetNext()
+			if err != nil {
+				e <- err
+				t.Errorf("unexpected error %v", err)
+				continue
+			}
+			read++
+		}
+		fmt.Println(read)
+	}
+	wg := &sync.WaitGroup{}
+	for i := 0; i < 5; i++ {
+		wg.Add(1)
+		go readFun(wg)
+	}
+	wg.Wait()
+	if len(e) > 0 {
+		t.Errorf("errors detected in the error channel but none expected")
 	}
 }


### PR DESCRIPTION
### What

Combined LAS reader used to be called from a single goroutine and was not thread safe. From V2.0.0 final this is no longer the case, however the `GetNext()` function was not made thread safe. 

This change fixes:
1. The race condition via CAS operations 
2. An infinite deadlock due to a lack of lock release on error inside the golas reader

### Issue ref
See https://github.com/mfbonfigli/gocesiumtiler/issues/59